### PR TITLE
🔧fix: add class static var to storage as cache token response

### DIFF
--- a/dymoapi/branches/private.py
+++ b/dymoapi/branches/private.py
@@ -1,11 +1,11 @@
 import requests
-from ..config import BASE_URL, set_base_url
+from ..config import get_base_url, set_base_url
 from ..exceptions import APIError, BadRequestError
 
 def is_valid_data(token, data):
     if not any([key in list(data.keys()) for key in ["email", "phone", "domain", "creditCard", "ip", "wallet"]]): raise BadRequestError("You must provide at least one parameter.")
     try:
-        response = requests.post(f"{BASE_URL}/v1/private/secure/verify", json=data, headers={"Authorization": token})
+        response = requests.post(f"{get_base_url()}/v1/private/secure/verify", json=data, headers={"Authorization": token})
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e: raise APIError(str(e))
@@ -16,7 +16,7 @@ def send_email(token, data):
     if not data.get("subject"): raise BadRequestError("You must provide a subject for the email to be sent.")
     if not data.get("html"): raise BadRequestError("You must provide HTML.")
     try:
-        response = requests.post(f"{BASE_URL}/v1/private/sender/sendEmail", json=data, headers={"Authorization": token})
+        response = requests.post(f"{get_base_url()}/v1/private/sender/sendEmail", json=data, headers={"Authorization": token})
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e: raise APIError(str(e))
@@ -32,7 +32,7 @@ def get_random(token, data):
     if data.min < -1000000000 or data.min > 1000000000: raise BadRequestError("'min' must be an integer in the interval [-1000000000}, 1000000000].")
     if data.max < -1000000000 or data.max > 1000000000: raise BadRequestError("'max' must be an integer in the interval [-1000000000}, 1000000000].")
     try:
-        response = requests.post(f"{BASE_URL}/v1/private/srng", json=data, headers={"Authorization": token})
+        response = requests.post(f"{get_base_url()}/v1/private/srng", json=data, headers={"Authorization": token})
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e: raise APIError(str(e))

--- a/dymoapi/branches/public.py
+++ b/dymoapi/branches/public.py
@@ -1,6 +1,6 @@
 import re, requests
 from urllib.parse import quote
-from ..config import BASE_URL, set_base_url
+from ..config import get_base_url, set_base_url
 from ..exceptions import APIError, BadRequestError
 
 def get_prayer_times(data):
@@ -10,7 +10,7 @@ def get_prayer_times(data):
         "lon": data.get("lon")
     }
     try:
-        response = requests.get(f"{BASE_URL}/v1/public/islam/prayertimes", params=params)
+        response = requests.get(f"{get_base_url()}/v1/public/islam/prayertimes", params=params)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e: raise APIError(str(e))
@@ -19,7 +19,7 @@ def satinizer(data):
     try:
         input_value = data.get("input")
         if input_value is None: raise BadRequestError("You must specify at least the input.")
-        response = requests.get(f"{BASE_URL}/v1/public/inputSatinizer", params={"input":quote(input_value)})
+        response = requests.get(f"{get_base_url()}/v1/public/inputSatinizer", params={"input":quote(input_value)})
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e: raise APIError(str(e))
@@ -49,7 +49,7 @@ def is_valid_pwd(data):
         if max_length is not None:
             if not isinstance(max_length, int) or max_length < 32 or max_length > 100: raise BadRequestError("If you provide a maximum it must be valid.")
             params["max"] = max_length
-        response = requests.get(f"{BASE_URL}/v1/public/validPwd", params=params)
+        response = requests.get(f"{get_base_url()}/v1/public/validPwd", params=params)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e: raise APIError(str(e))
@@ -57,7 +57,7 @@ def is_valid_pwd(data):
 def new_url_encrypt(url):
     try:
         if url is None or not (url.startswith("https://") or url.startswith("http://")): raise BadRequestError("You must provide a valid url.")
-        response = requests.get(f"{BASE_URL}/v1/public/url-encrypt", params={"url": url})
+        response = requests.get(f"{get_base_url()}/v1/public/url-encrypt", params={"url": url})
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e: raise APIError(str(e))

--- a/dymoapi/config.py
+++ b/dymoapi/config.py
@@ -3,3 +3,6 @@ BASE_URL = "https://api.tpeoficial.com"
 def set_base_url(is_local: bool):
     global BASE_URL
     BASE_URL = "http://localhost:3050" if is_local else "https://api.tpeoficial.com"
+
+def get_base_url():
+    return BASE_URL


### PR DESCRIPTION
# Title
Move Tokens to Static Properties in DymoAPI Class

## Description
This PR refactors the DymoAPI class to move the tokens_response and tokens_verified properties out of the constructor and make them static. This change improves code organization and ensures that these properties are shared across all instances of the DymoAPI class.

## Changes
- Moved the tokens_response and tokens_verified properties to be static properties of the DymoAPI class.
- Updated the initialize_tokens method to use the static properties.
- Updated the set_base_url method for better URL configuration based on the environment.

## How to Test It
- Initialize the DymoAPI class with different configurations.
- Confirm that tokens_response and tokens_verified are shared across instances.
- Ensure the URL base is set correctly based on the environment (local or production).

