### PR TITLE
🔧fix: change AuthenticationError with log alert

### DIFF
--- a/dymoapi/dymoapi.py
+++ b/dymoapi/dymoapi.py
@@ -2,6 +2,7 @@ import logging
 from .utils.basics import DotDict
 import os, sys, requests, importlib
 from datetime import datetime, timedelta
+from .exceptions import AuthenticationError
 from .config import set_base_url, get_base_url
 import dymoapi.response_models as response_models
 from .services.autoupload import check_for_updates
@@ -41,13 +42,12 @@ class DymoAPI:
             response = requests.post(f"{self.base_url}/v1/dvr/tokens", json={"tokens": tokens})
             response.raise_for_status()
             data = response.json()
-            if self.root_api_key and not data.get("root"): return logging.error("Invalid root token.")
-            if self.api_key and not data.get("private"): return logging.error("Invalid private token.")
+            if self.root_api_key and data.get("root"): raise AuthenticationError("Invalid root token.")
+            if self.api_key and not data.get("private"): raise AuthenticationError("Invalid private token.")
             DymoAPI.tokens_response = data
             DymoAPI.tokens_verified = True
             print("[Dymo API] Tokens initialized successfully.")
-        except requests.RequestException as e:
-            print(f"[Dymo API] Error during token validation: {e}")
+        except (requests.RequestException, AuthenticationError) as e:
             return logging.error("Token validation error: {e}")
 
     def is_valid_data(self, data) -> response_models.DataVerifierResponse:


### PR DESCRIPTION
# Title
Handle authentication errors in DymoAPI without crashing api

## Description:
This PR improves the handling of authentication errors in the DymoAPI class. Instead of causing the application to crash when the API is down or there’s an error verifying tokens, these errors are now caught and logged as warnings or using console.error, ensuring the application continues to function.

## Changes
- Authentication Error Handling: removed to capture exceptions during authentication and token verification processes.
- Logging Warnings and Errors: Utilized logging.warning and logging.error (or an equivalent logging function) to log errors instead of letting the application crash.

## How to Test It:
- Simulate an authentication API downtime.
- Attempt to authenticate and verify tokens during this scenario.
- Verify that the errors are logged and the application does not crash.